### PR TITLE
chore: add `.idea` to `.gitignore`.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 kiro.db
 config.json
+
+.idea


### PR DESCRIPTION
Add `.idea` directory to `.gitignore` to prevent committing local IntelliJ IDEA configuration files.